### PR TITLE
reject nil resources

### DIFF
--- a/lib/cloud_shaped/template_builder.rb
+++ b/lib/cloud_shaped/template_builder.rb
@@ -52,6 +52,7 @@ module CloudShaped
       else
         resource(type, *args, &block)
       end
+      resources.reject! { |_k, v| v.nil? }
     end
 
     # Declares an Output.


### PR DESCRIPTION
If the resource is generated by a method, that method may return nil to indicate no resource is needed. This patch makes that not pass the nil up to the CF template.
