### PR TITLE
Interpolation breaks when refs to AWS resources are surrounded by other text

### DIFF
--- a/lib/cloud_shaped/interpolation.rb
+++ b/lib/cloud_shaped/interpolation.rb
@@ -26,7 +26,7 @@ module CloudShaped
 
     def interpolate_line(line, delimiters)
       open, close = delimiters
-      tokens = line.split(/(#{Regexp.quote(open)}\w+#{Regexp.quote(close)})/)
+      tokens = line.split(/(#{Regexp.quote(open)}[\w:]+#{Regexp.quote(close)})/)
       tokens.reject!(&:empty?)
       tokens.map do |token|
         if token =~ /^#{Regexp.quote(open)}([\w:]+)(?:\.(\w+))?#{Regexp.quote(close)}$/

--- a/spec/cloud_shaped/interpolation_spec.rb
+++ b/spec/cloud_shaped/interpolation_spec.rb
@@ -48,6 +48,26 @@ describe CloudShaped::Interpolation do
 
     end
 
+    context "with a built-in CloudFormation resource surrounded by other stuff" do
+
+      let(:input) { "prefix-{{AWS::StackName}}-suffix" }
+
+      it "generates a Ref" do
+        expect(output).to eq(
+          {
+            "Fn::Join" => [
+              "", [
+                "prefix-",
+                { "Ref" => "AWS::StackName" },
+                "-suffix"
+              ]
+            ]
+          }
+        )
+      end
+
+    end
+
     context "with a resource name and attribute" do
 
       let(:input) { "{{loadBalancer.cname}}" }


### PR DESCRIPTION
As seen in the additional spec.

Fixed by tweaking regex used to tokenize line of text to allow 1 or more words between delimiters.
